### PR TITLE
More robust git repository detection.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CFLAGS=-std=gnu99 -Wall -Wextra -Wno-parentheses -Wno-unused-result -Wno-missing
 VERSION=1.1
 YEAR=2015
 BUILD_DATE:=$(shell date '+%Y-%m-%d')
-BUILD_COMMIT:=$(shell if [ -d .git ] ; then git describe --always ; else echo '<unknown>' ; fi)
+BUILD_COMMIT:=$(shell if git rev-parse >/dev/null 2>/dev/null ; then git describe --always ; else echo '<unknown>' ; fi)
 CFLAGS += -DVERSION='"$(VERSION)"' -DYEAR='"$(YEAR)"' -DBUILD_DATE='"$(BUILD_DATE)"' -DBUILD_COMMIT='"$(BUILD_COMMIT)"'
 
 PREFIX = $(DESTDIR)/usr/local


### PR DESCRIPTION
Sometimes (i.e., in case of submodules) you can run git commands
even if the .git directory is not present. This change fixes
commit detection in such cases.