### PR TITLE
Makefile: fix install -D with multiple sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 	rm -f docbook-xsl.css
 
 install: isolate isolate-check-environment
-	install -D $^ $(BINDIR)
+	install -t $(BINDIR) -D $^
 	chmod u+s $(BINDIR)/$<
 	install -d $(BOXDIR)
 	install -m 644 -D default.cf $(CONFIG)


### PR DESCRIPTION
This fixes a regression in the *install* target, introduced by 0933101.
```console
$ touch foo bar

$ install -D foo bar some/folder
install: target 'some/folder' is not a directory

$ install -t some/folder -D foo bar
$ tree some
some
└── folder
    ├── bar
    └── foo
```