### PR TITLE
Add travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+
+compiler: gcc
+
+addons:
+  apt:
+    packages:
+      - asciidoc
+      - libcap-dev
+      - libxml2-utils
+      - xsltproc
+      - docbook-xml
+      - docbook-xsl
+
+script:
+  - make DESTDIR=/tmp/isolate
+  - make DESTDIR=/tmp/isolate install


### PR DESCRIPTION
This enables automatic Travis CI builds. For the moment this config just builds the project+doc and installs it to an arbitrary prefix. It could be a good idea to introduce some tests, one day.

---

As we can see on [my isolate fork build log](https://travis-ci.org/Zopieux/isolate/builds/260385159#L470), the regression introduced by 0933101 and fixed by #32 would have been obvious thanks to this.