### PR TITLE
Little docs fix according to real behavior.

### DIFF
--- a/isolate.1.txt
+++ b/isolate.1.txt
@@ -101,9 +101,8 @@ OPTIONS
 
 *-r, --stderr=*'file'::
 	Redirect standard error output to 'file'. The 'file' has to be accessible
-	inside the sandbox. Otherwise, standard error output is inherited from
-	the parent process and both the sandboxed process and the sandbox manager
-	can write their status messages to it.
+	inside the sandbox. Otherwise, standard error output is redirected to stdout
+	(either inherited from parent process or redirected to file via previous option).
 
 *-c, --chdir=*'dir'::
 	Change directory to 'dir' before executing the program. This path must be
@@ -255,6 +254,9 @@ of format 'key'*:*'value'. The following keys are defined:
 	Run time of the program in fractional seconds.
 *time-wall*::
 	Wall clock time of the program in fractional seconds.
+
+Notice, that many of these keys maybe absent.
+For example, no *exitcode*, *status* or *message* on normal termination.
 
 RETURN VALUE
 ------------

--- a/isolate.1.txt
+++ b/isolate.1.txt
@@ -166,11 +166,11 @@ requested by directory rules:
 
 *-d, --dir=*'in'*=*'out'[*:*'options']::
 	Bind the directory 'out' as seen by the caller to the path 'in' inside the sandbox.
-	If there already was a directory rule for 'out', it is replaced.
+	If there already was a directory rule for 'in', it is replaced.
 
 *-d, --dir=*'dir'[*:*'options']::
 	Bind the directory +/+'dir' to 'dir' inside the sandbox.
-	If there already was a directory rule for 'out', it is replaced.
+	If there already was a directory rule for 'in', it is replaced.
 
 *-d, --dir=*'in'*=*::
 	Remove a directory rule for the path 'in' inside the sandbox.


### PR DESCRIPTION
 ### --stderr option behavior
According to code:
https://github.com/ioi/isolate/blob/a86f4a7ee165075a3356d77d9c7384304d64df9d/isolate.c#L536-L543

According to docs:
```
 -r, --stderr=file
    Redirect standard error output to file. The file has to be accessible inside the sandbox. Otherwise,
    standard error output is inherited from the parent process and both the sandboxed process and the
    sandbox manager can write their status messages to it. 
```

Which is wrong, fixed it.

### Notice about absence of keys in meta-files
When I haven't `status` or `exitcode` in a meta-file I thought I missed some options or maybe I found a bug or maybe they are defined but never written. Took me awhile that they are present only on non-zero exit code. So, I made a notice about this. 