### PR TITLE
Reset memory max usage in cgroup

### DIFF
--- a/cg.c
+++ b/cg.c
@@ -238,6 +238,8 @@ cg_enter(void)
     {
       cg_write(CG_MEMORY, "memory.limit_in_bytes", "%lld\n", (long long) cg_memory_limit << 10);
       cg_write(CG_MEMORY, "?memory.memsw.limit_in_bytes", "%lld\n", (long long) cg_memory_limit << 10);
+      cg_write(CG_MEMORY, "memory.max_usage_in_bytes", "0\n");
+      cg_write(CG_MEMORY, "?memory.memsw.max_usage_in_bytes", "0\n");
     }
 
   if (cg_timing)


### PR DESCRIPTION
When initializing cgroup controllers `cpuacct.usage` is reset to zero,
but `memory.max_usage_in_bytes` and `memory.memsw.max_usage_in_bytes` aren't.

I think it's a good idea to reset them too, because then you can run several programs in the same isolate box without recreating it and have  `cg-mem` reported for the last run instead of max across all runs.