### PR TITLE
Prevent setrlimit from failing

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -543,6 +543,11 @@ setup_fds(void)
 static void
 setup_rlim(const char *res_name, int res, rlim_t limit)
 {
+  struct rlimit old;
+  if (getrlimit(res, &old) < 0)
+    die("getrlimit(%s, %jd)", res_name, (intmax_t) limit);
+  if (old.rlim_max < limit)
+    limit = old.rlim_max;
   struct rlimit rl = { .rlim_cur = limit, .rlim_max = limit };
   if (setrlimit(res, &rl) < 0)
     die("setrlimit(%s, %jd)", res_name, (intmax_t) limit);


### PR DESCRIPTION
`setrlimit` in case of a previously set lower hard limit causes isolate to die.
The fix is to get the current hard limit and adjust the requested one.