### PR TITLE
Use setrlimit() on the stack only when specified

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -559,12 +559,14 @@ setup_rlimits(void)
   if (fsize_limit)
     RLIM(FSIZE, (rlim_t)fsize_limit * 1024);
 
-  RLIM(STACK, (stack_limit ? (rlim_t)stack_limit * 1024 : RLIM_INFINITY));
-  RLIM(NOFILE, 64);
-  RLIM(MEMLOCK, 0);
+  if (stack_limit)
+    RLIM(STACK, (rlim_t)stack_limit * 1024);
 
   if (max_processes)
     RLIM(NPROC, max_processes);
+
+  RLIM(NOFILE, 64);
+  RLIM(MEMLOCK, 0);
 
 #undef RLIM
 }


### PR DESCRIPTION
There is no need to call setrlimit() on the stack size when the user is
not providing any stack limit. Not providing any value should mean "use
the defaults", as it is the case for the other limits.

This partially fixes/workarounds #42 : not providing a limit uses the system defaults instead of INFINITY.