### PR TITLE
cg: add cg-oom-killed meta entry

### DIFF
--- a/cg.c
+++ b/cg.c
@@ -280,6 +280,17 @@ cg_stats(void)
     }
   if (mem)
     meta_printf("cg-mem:%lld\n", mem >> 10);
+
+  // OOM kill detection
+  if (cg_read(CG_MEMORY, "?memory.oom_control", buf))
+    {
+      int oom_killed = 0;
+      const char *oom_kill_line = strstr(buf, "oom_kill ");
+
+      if (oom_kill_line && sscanf(oom_kill_line, "oom_kill %d", &oom_killed))
+        if (oom_killed)
+          meta_printf("cg-oom-killed:1\n");
+    }
 }
 
 void

--- a/cg.c
+++ b/cg.c
@@ -287,7 +287,9 @@ cg_stats(void)
       int oom_killed = 0;
       const char *oom_kill_line = strstr(buf, "oom_kill ");
 
-      if (oom_kill_line && sscanf(oom_kill_line, "oom_kill %d", &oom_killed))
+      if (oom_kill_line
+          && (oom_kill_line == buf || *(oom_kill_line - 1) == '\n')
+          && sscanf(oom_kill_line, "oom_kill %d", &oom_killed))
         if (oom_killed)
           meta_printf("cg-oom-killed:1\n");
     }

--- a/isolate.1.txt
+++ b/isolate.1.txt
@@ -230,6 +230,9 @@ of format 'key'*:*'value'. The following keys are defined:
 *cg-mem*::
 	When control groups are enabled, this is the total memory use
 	by the whole control group (in kilobytes).
+*cg-oom-killed*::
+	Present when the program was killed by the OOM killer (e.g., because it has
+	exceeded the memory limit of its control group).
 *csw-forced*::
 	Number of context switches forced by the kernel.
 *csw-voluntary*::

--- a/isolate.1.txt
+++ b/isolate.1.txt
@@ -232,7 +232,8 @@ of format 'key'*:*'value'. The following keys are defined:
 	by the whole control group (in kilobytes).
 *cg-oom-killed*::
 	Present when the program was killed by the OOM killer (e.g., because it has
-	exceeded the memory limit of its control group).
+	exceeded the memory limit of its control group). Only present for recent
+	kernel versions (Linux v4.13 and after).
 *csw-forced*::
 	Number of context switches forced by the kernel.
 *csw-voluntary*::


### PR DESCRIPTION
It is hard to judge solely from the meta output whether a program has
been SIGKILL by the OOM killer or something else.

The cgroup API provides us with a memory.oom_control file that contains
a value "oom_kill" which contains the number of times the cgroup has
received an OOM kill. If this value is greater than 0, we report that
there was an OOM kill in the meta file with the cg-oom-killed entry.