### PR TITLE
Ensuring quota strings are correctly validated

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -1032,7 +1032,7 @@ main(int argc, char **argv)
 	sep = strchr(optarg, ',');
 	if (!sep)
 	  usage("Invalid quota specified: %s\n", optarg);
-	block_quota = opt_uint(optarg);
+	block_quota = opt_uint(strndup(optarg, sep-optarg));
 	inode_quota = opt_uint(sep+1);
 	break;
       case 'r':


### PR DESCRIPTION
Previously, the validation for the quota would pass the full quota string (i.e. 4096,4096) to
the validation function as the "block_quota" variable. This fix passes the substring before the ',' as block_quota variable instead.

Fixes #67

Before: 
```
$ sudo ./isolate --quota=40960,40960  --init
Invalid numeric parameter: 40960,40960
```
After:
```
$ sudo ./isolate --quota=40960,40960  --init
/var/local/lib/isolate/0
```