### PR TITLE
Increase the maximum number of open files to 4096

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -657,7 +657,7 @@ setup_rlimits(void)
     RLIM(FSIZE, (rlim_t)fsize_limit * 1024);
 
   RLIM(STACK, (stack_limit ? (rlim_t)stack_limit * 1024 : RLIM_INFINITY));
-  RLIM(NOFILE, 64);
+  RLIM(NOFILE, 4096);
   RLIM(MEMLOCK, 0);
 
   if (max_processes)


### PR DESCRIPTION
Hi,
we came across the same problem as #85 when executing groovy runtime. Open files limit of 64 is just too low, consider please my change to 4096. It might seem high, but I think it is high enough to not interfere with sandboxed program and low enough to not cause any real problems on host machine.
Thanks!