### PR TITLE
Fix: If call of execve fails, it is usually fault of the program being executed

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -680,7 +680,7 @@ box_inside(char **args)
     die("chdir: %m");
 
   execve(args[0], args, env);
-  die("execve(\"%s\"): %m", args[0]);
+  err("execve(\"%s\"): %m", args[0]);
 }
 
 /*** Proxy ***/


### PR DESCRIPTION
Hi,
On a regular basis we run into issue described in #77. This PR changes error reporting of isolate when execve call fails, because  it usually fails in case of problem with the sandboxed program. It would be really great to see this change in isolate upstream.
Thanks!