### PR TITLE
Add customizable open files limit

### DIFF
--- a/isolate.1.txt
+++ b/isolate.1.txt
@@ -77,6 +77,10 @@ OPTIONS
 	Limit process stack to 'size' kilobytes. By default, the whole address
 	space is available for the stack, but it is subject to the *--mem* limit.
 
+*-n, --open-files=*'max'::
+	Limit number of open files to 'max'. The default value is 64. Setting this
+	option to 0 will result in unlimited open files.
+
 *-f, --fsize=*'size'::
 	Limit size of files created (or modified) by the program to 'size' kilobytes.
 	In most cases, it is better to restrict overall disk usage by a disk quota

--- a/isolate.c
+++ b/isolate.c
@@ -927,6 +927,7 @@ Options:\n\
     --share-net\t\tShare network namespace with the parent process\n\
 -s, --silent\t\tDo not print status messages except for fatal errors\n\
 -k, --stack=<size>\tLimit stack size to <size> KB (default: 0=unlimited)\n\
+-n, --open-files=<max>\tLimit number of open files <max> KB (default: 64)\n\
 -r, --stderr=<file>\tRedirect stderr to <file>\n\
     --stderr-to-stdout\tRedirect stderr to stdout\n\
 -i, --stdin=<file>\tRedirect stdin from <file>\n\

--- a/isolate.c
+++ b/isolate.c
@@ -72,6 +72,7 @@ static int silent;
 static int fsize_limit;
 static int memory_limit;
 static int stack_limit;
+static int open_file_limit = 64;
 int block_quota;
 int inode_quota;
 static int max_processes = 1;
@@ -656,8 +657,10 @@ setup_rlimits(void)
   if (fsize_limit)
     RLIM(FSIZE, (rlim_t)fsize_limit * 1024);
 
+  if (open_file_limit)
+    RLIM(NOFILE, (rlim_t)open_file_limit);
+
   RLIM(STACK, (stack_limit ? (rlim_t)stack_limit * 1024 : RLIM_INFINITY));
-  RLIM(NOFILE, 64);
   RLIM(MEMLOCK, 0);
 
   if (max_processes)
@@ -984,6 +987,7 @@ static const struct option long_opts[] = {
   { "share-net",	0, NULL, OPT_SHARE_NET },
   { "silent",		0, NULL, 's' },
   { "stack",		1, NULL, 'k' },
+  { "open-files",		1, NULL, 'n' },
   { "stderr",		1, NULL, 'r' },
   { "stderr-to-stdout",	0, NULL, OPT_STDERR_TO_STDOUT },
   { "stdin",		1, NULL, 'i' },
@@ -1050,6 +1054,9 @@ main(int argc, char **argv)
         break;
       case 'k':
 	stack_limit = opt_uint(optarg);
+	break;
+      case 'n':
+	open_file_limit = opt_uint(optarg);
 	break;
       case 'i':
 	redir_stdin = optarg;

--- a/isolate.c
+++ b/isolate.c
@@ -988,7 +988,7 @@ static const struct option long_opts[] = {
   { "share-net",	0, NULL, OPT_SHARE_NET },
   { "silent",		0, NULL, 's' },
   { "stack",		1, NULL, 'k' },
-  { "open-files",		1, NULL, 'n' },
+  { "open-files",	1, NULL, 'n' },
   { "stderr",		1, NULL, 'r' },
   { "stderr-to-stdout",	0, NULL, OPT_STDERR_TO_STDOUT },
   { "stdin",		1, NULL, 'i' },


### PR DESCRIPTION
In order to fix cases like https://github.com/ioi/isolate/pull/97#issuecomment-820368812.

This PR adds a new argument `--open-files`/`-n` which takes an integer value corresponding to the maximum allowed number of open files.
