### PR TITLE
Update makefile in order to actually work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BOXDIR = $(VARPREFIX)/lib/isolate
 isolate: isolate.o util.o rules.o cg.o config.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
-%.o: %.c isolate.h config.h
+%.o: %.c isolate.h
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 isolate.o: CFLAGS += -DVERSION='"$(VERSION)"' -DYEAR='"$(YEAR)"' -DBUILD_DATE='"$(BUILD_DATE)"' -DBUILD_COMMIT='"$(BUILD_COMMIT)"'


### PR DESCRIPTION
The `config.h` file was removed a long time ago in favour of a dynamic config file. Unfortunately, it wasn't removed from the makefile and as such the %.o recipe fails to run (instead, it uses one of the make builtins). This simple commit makes the make recipe actually work.