### PR TITLE
changing the order of setting memory limit_in_bytes

### DIFF
--- a/cg.c
+++ b/cg.c
@@ -238,8 +238,8 @@ cg_enter(void)
 
   if (cg_memory_limit)
     {
-      cg_write(CG_MEMORY, "memory.limit_in_bytes", "%lld\n", (long long) cg_memory_limit << 10);
       cg_write(CG_MEMORY, "?memory.memsw.limit_in_bytes", "%lld\n", (long long) cg_memory_limit << 10);
+      cg_write(CG_MEMORY, "memory.limit_in_bytes", "%lld\n", (long long) cg_memory_limit << 10);
       cg_write(CG_MEMORY, "memory.max_usage_in_bytes", "0\n");
       cg_write(CG_MEMORY, "?memory.memsw.max_usage_in_bytes", "0\n");
     }


### PR DESCRIPTION
updated `cg.c` to set `memory.memsw.limit_in_bytes` before setting `memory.limit_in_bytes`, since value already present in `memory.memsw.limit_in_bytes` was preventing setting `memory.limit_in_bytes` to anything more than `memory.memsw.limit_in_bytes`.