### PR TITLE
Read memory usage with cgroups v2

### DIFF
--- a/cg.c
+++ b/cg.c
@@ -259,22 +259,23 @@ cg_stats(void)
   if (!cg_enable)
     return;
 
+  char buf[CG_BUFSIZE];
   char key[CG_BUFSIZE], val[CG_BUFSIZE];
 
-#if 0	// FIXME: I see no way how to ask for maximum memory usage
   // Memory usage statistics
   unsigned long long mem=0, memsw=0;
-  if (cg_read(CG_MEMORY, "?memory.max_usage_in_bytes", buf))
+  if (cg_read("?memory.peak", buf))
     mem = atoll(buf);
-  if (cg_read(CG_MEMORY, "?memory.memsw.max_usage_in_bytes", buf))
+#if 0	// FIXME: I see no way how to ask for maximum swap memory usage
+  if (cg_read("?memory.memsw.max_usage_in_bytes", buf))
     {
       memsw = atoll(buf);
       if (memsw > mem)
 	mem = memsw;
     }
+#endif
   if (mem)
     meta_printf("cg-mem:%lld\n", mem >> 10);
-#endif
 
   // OOM kill detection
   FILE *f = cg_fopen("memory.events");


### PR DESCRIPTION
Use `memory.peak`, which replaces `memory.max_usage_in_bytes` from v1.

See https://github.com/ioi/isolate/issues/78#issuecomment-1221414436.

It seems that there is still no replacement for `memory.memsw.max_usage_in_bytes`, so there is no way to read maximum swap usage. This should be acceptable for using isolate as a contest sandbox, where swap is supposed to be disabled for ensuring reproducibility.

So perhaps it would for now be sufficient to leave it like this, and add proper documentation that swap memory is not accounted for. On a related note, I am not sure how obvious it was that with v1 the reported memory usage was the maximum of memory peak and swap memory peak, which I assume could be smaller than the peak of the total memory consumption, so clarifying how or if swap memory consumption is regarded might be good either way.