### PR TITLE
Fix cgroup memory limits not working

### DIFF
--- a/cg.c
+++ b/cg.c
@@ -238,8 +238,12 @@ cg_enter(void)
 
   if (cg_memory_limit)
     {
-      cg_write(CG_MEMORY, "?memory.memsw.limit_in_bytes", "%lld\n", (long long) cg_memory_limit << 10);
+      // Reset any existing limit on memory.memsw.limit_in_bytes,
+      // as memory.limit_in_bytes cannot be set higher than it.
+      cg_write(CG_MEMORY, "?memory.memsw.limit_in_bytes", "-1\n");
+
       cg_write(CG_MEMORY, "memory.limit_in_bytes", "%lld\n", (long long) cg_memory_limit << 10);
+      cg_write(CG_MEMORY, "?memory.memsw.limit_in_bytes", "%lld\n", (long long) cg_memory_limit << 10);
       cg_write(CG_MEMORY, "memory.max_usage_in_bytes", "0\n");
       cg_write(CG_MEMORY, "?memory.memsw.max_usage_in_bytes", "0\n");
     }


### PR DESCRIPTION
The changes from #109 attempted to fix an issue where cgroup memory limits could not be increased across runs within the same sandbox, but this actually broke memory limits on the initial run, as attempting to set `memory.memsw.limit_in_bytes` before `memory.limit_in_bytes` has been set results in an error (which isolate ignores due to the `?` flag). For example, when running the following commands, memory limits are ignored on the first run, but work on the second run:
```
isolate -b0 --init --cg
isolate -b0 --cg --cg-mem 16384 --run -- /usr/bin/python3 -c '[0]*10000000'
isolate -b0 --cg --cg-mem 32768 --run -- /usr/bin/python3 -c '[0]*10000000'
isolate -b0 --cleanup --cg
```

This PR restores the original ordering and proposes an alternative fix: reset any existing limit on `memory.memsw.limit_in_bytes` before setting `memory.limit_in_bytes` to allow the limit to be increased.