### PR TITLE
Fail-safe when memory.swap.max is not available

### DIFF
--- a/cg.c
+++ b/cg.c
@@ -235,7 +235,7 @@ cg_enter(void)
   if (cg_memory_limit)
     {
       cg_write("memory.max", "%lld\n", (long long) cg_memory_limit << 10);
-      cg_write("memory.swap.max", "0\n");
+      cg_write("?memory.swap.max", "0\n");
     }
 
   struct cf_per_box *cf = cf_current_box();


### PR DESCRIPTION
This PR closes #137.

It seems like if the kernel is not compiled with `CONFIG_MEMCG_SWAP`, `memory.swap.max` and related are not available. Currently, `isolate` just crashes when this happens, since it tries to write to a file that may not exist. If the user does not use swap, writing to this file does not change behavior.

It should be noted, though, that the user could:
* Enable swap;
* Not have the cgroups controller for swap available in the machine;
* End up using swap when using isolate,

However, this will not happen in the majority of the cases; the manual recommends not setting up swap and having a kernel compiled without this feature is result of running in an environment with a custom kernel (which sometimes you have no control over).

So this PR just allows isolate to ignore the fact that the controller is not there. A more diligent solution would also include warning that the file does not exist.