### PR TITLE
cg2: Use strdup for saving cf_cg_root value from file

### DIFF
--- a/cg.c
+++ b/cg.c
@@ -190,7 +190,7 @@ cg_init(void)
 	*sep = 0;
 
       fclose(f);
-      cf_cg_root = line;
+      cf_cg_root = xstrdup(line);
     }
 
   if (!dir_exists(cf_cg_root))


### PR DESCRIPTION
It seems that on Fedora systems, probably due to some hardening features, memory `malloc`-ed by the `getline()` call when trying to parse the file (when the cgroup root path is in auto mode) is improperly handled after the clone call. Instead of directly setting the pointer to that memory, using `strdup` again seems to do the trick and properly allocate memory just for the string.

In addition, this makes the setup of the cf_cg_root variable consistent with config.c, in which it is also strdup-ed in the `cf_string` function. 

If accepted, this pull request can close #142.