### PR TITLE
Added a dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ To compile Isolate, you need:
 
   - headers for the libsystemd library (libsystemd-dev package) for compilation
     of isolate-cg-keeper
+    
+  - Additionally, you'll need pkg-config for managing library-specific compilation flags.
+
 
 You may need `a2x` (found in [AsciiDoc](https://asciidoc-py.github.io/a2x.1.html)) for building manual.
 But if you only want the isolate binary, you can just run `make isolate`


### PR DESCRIPTION
If pkg-config is not installed on the system running `sudo make install`, it will throw the following error:

> isolate-cg-keeper.c:(.text+0x65e): undefined reference to `sd_notify'

This is because of the following line in the Makefile.

`SYSTEMD_LIBS := $(shell pkg-config libsystemd --libs)`