### PR TITLE
Fix wall-clock time calculation: use `clock_gettime` instead of `gettimeofday`

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -111,7 +111,7 @@ static bool invoked_by_root;
 static int partial_line;
 static int cleanup_ownership;
 
-static struct timeval start_time;
+static struct timespec start_time;
 static int ticks_per_sec;
 static int total_ms, wall_ms;
 static volatile sig_atomic_t timer_tick, interrupt;
@@ -524,10 +524,10 @@ read_proc_file(char *buf, char *name, int *fdp)
 static int
 get_wall_time_ms(void)
 {
-  struct timeval now, wall;
-  gettimeofday(&now, NULL);
-  timersub(&now, &start_time, &wall);
-  return wall.tv_sec*1000 + wall.tv_usec/1000;
+  struct timespec now, wall;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  timespec_sub(&now, &start_time, &wall);
+  return wall.tv_sec*1000 + wall.tv_nsec/1000000;
 }
 
 static int
@@ -598,7 +598,7 @@ box_keeper(void)
   close(error_pipes[1]);
   close(status_pipes[1]);
 
-  gettimeofday(&start_time, NULL);
+  clock_gettime(CLOCK_MONOTONIC, &start_time);
   ticks_per_sec = sysconf(_SC_CLK_TCK);
   if (ticks_per_sec <= 0)
     die("Invalid ticks_per_sec!");

--- a/isolate.h
+++ b/isolate.h
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <time.h>
 
 #define NONRET __attribute__((noreturn))
 #define UNUSED __attribute__((unused))
@@ -36,6 +37,8 @@ extern gid_t box_gid, orig_gid;
 void *xmalloc(size_t size);
 char *xstrdup(char *str);
 char * __attribute__((format(printf,1,2))) xsprintf(const char *fmt, ...);
+
+void timespec_sub(const struct timespec *a, const struct timespec *b, struct timespec *result);
 
 int dir_exists(char *path);
 void rmtree(char *path);

--- a/util.c
+++ b/util.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <sys/fsuid.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 void *
@@ -49,6 +50,19 @@ char *xsprintf(const char *fmt, ...)
 
   va_end(args);
   return out;
+}
+
+void
+timespec_sub(const struct timespec *a, const struct timespec *b, struct timespec *result)
+{
+  result->tv_sec  = a->tv_sec - b->tv_sec;
+  result->tv_nsec = a->tv_nsec - b->tv_nsec;
+
+  if (result->tv_nsec < 0)
+  {
+    result->tv_sec  -= 1;
+    result->tv_nsec += 1000000000L;
+  }
 }
 
 int


### PR DESCRIPTION
In the case of `gettimeofday`, inaccuracies may occur when the system clock is adjusted due to NTP or leap second handling. 
As a result, calculating the difference between two time points can produce incorrect values.

Issue #178 was related to this: for very short execution times, the `time-wall` value occasionally appeared as negative.

Therefore, the method of calculating the time difference has been changed from `gettimeofday` to `clock_gettime`.

For more details, please refer to the commit history. :)


Close #178 
See also: [POSIX.1-2008 specification for gettimeofday (obsolescent function)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html)