### PR TITLE
fix missing __attribute__(format(printf)) on die()

### DIFF
--- a/isolate.c
+++ b/isolate.c
@@ -183,7 +183,7 @@ lock_box(bool is_init)
 
   int n = read(lock_fd, &lock, sizeof(lock));
   if (n < 0)
-    die("Cannot read %s: %m");
+    die("Cannot read %s: %m", lock_name);
 
   if (n > 0)
     {

--- a/isolate.h
+++ b/isolate.h
@@ -16,7 +16,7 @@
 
 /* isolate.c */
 
-void die(char *msg, ...) NONRET;
+void NONRET __attribute__((format(printf,1,2))) die(char *msg, ...);
 void NONRET __attribute__((format(printf,1,2))) err(char *msg, ...);
 void __attribute__((format(printf,1,2))) msg(char *msg, ...);
 


### PR DESCRIPTION
the declaration and definition of die() were mismatched, the declaration was missing the format(printf) attribute, which was hiding one format string warning.