### PR TITLE
Use CLONE_INTO_CGROUP to enter the box cgroup

### DIFF
--- a/cg.c
+++ b/cg.c
@@ -11,10 +11,14 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <linux/sched.h>
+#include <sched.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 static char cg_name[256];
@@ -223,27 +227,35 @@ cg_create(void)
     die("Failed to create control group %s: %m", path);
 }
 
-void
-cg_enter(void)
+pid_t
+cg_fork_and_enter(void)
 {
-  if (!cg_enable)
-    return;
+  struct clone_args cl_args = {
+    .exit_signal = SIGCHLD,
+    // everything else can be zero
+  };
+  int cg_fd = -1;
 
-  msg("Entering control group %s\n", cg_name);
-
-  cg_write("cgroup.procs", "%d\n", (int) getpid());
-
-  if (cg_memory_limit)
+  if (cg_enable)
     {
-      cg_write("memory.max", "%lld\n", (long long) cg_memory_limit << 10);
-      cg_write("?memory.swap.max", "0\n");
+      char path[PATH_MAX];
+      cg_makepath(path, sizeof(path), NULL);
+      cg_fd = open(path, O_PATH);
+      if (cg_fd < 0)
+	die("Could not open cgroup path: %m");
+
+      cl_args.flags |= CLONE_INTO_CGROUP;
+      cl_args.cgroup = cg_fd;
     }
 
-  struct cf_per_box *cf = cf_current_box();
-  if (cf->cpus)
-    cg_write("cpuset.cpus", "%s", cf->cpus);
-  if (cf->mems)
-    cg_write("cpuset.mems", "%s", cf->mems);
+  pid_t ret = syscall(SYS_clone3, &cl_args, sizeof(cl_args));
+  if (ret < 0)
+    die("Cannot run process, clone failed: %m");
+
+  if (cg_fd >= 0)
+    close(cg_fd);
+
+  return ret;
 }
 
 static int
@@ -286,6 +298,18 @@ cg_setup(void)
 {
   if (!cg_enable)
     return;
+
+  if (cg_memory_limit)
+    {
+      cg_write("memory.max", "%lld\n", (long long) cg_memory_limit << 10);
+      cg_write("?memory.swap.max", "0\n");
+    }
+
+  struct cf_per_box *cf = cf_current_box();
+  if (cf->cpus)
+    cg_write("cpuset.cpus", "%s", cf->cpus);
+  if (cf->mems)
+    cg_write("cpuset.mems", "%s", cf->mems);
 
   /*
    *  The box CG can be used by multiple invocations of "isolate --run",

--- a/isolate.c
+++ b/isolate.c
@@ -13,6 +13,7 @@
 #include <getopt.h>
 #include <grp.h>
 #include <limits.h>
+#include <linux/sched.h>
 #include <sched.h>
 #include <seccomp.h>
 #include <stdio.h>
@@ -25,6 +26,7 @@
 #include <sys/signal.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/vfs.h>
 #include <sys/wait.h>
@@ -582,7 +584,7 @@ check_timeout(void)
     }
 }
 
-static void
+static void NONRET
 box_keeper(void)
 {
   read_errors_from_fd = error_pipes[0];
@@ -928,7 +930,7 @@ setup_seccomp(void)
     die("seccomp_load: %s", strerror(-err));
 }
 
-static int
+static void NONRET
 box_inside(char **args)
 {
   setup_root();
@@ -960,11 +962,9 @@ setup_orig_credentials(void)
     die("setresuid: %m");
 }
 
-static int
-box_proxy(void *arg)
+static void NONRET
+box_proxy(char **args)
 {
-  char **args = arg;
-
   write_errors_to_fd = error_pipes[1];
   close(error_pipes[0]);
   close(status_pipes[0]);
@@ -1135,7 +1135,7 @@ find_box_pid(void)
   fclose(f);
 }
 
-static void
+static void NONRET
 run(char **argv)
 {
   if (!lock_box(false, false))
@@ -1158,15 +1158,15 @@ run(char **argv)
   setup_signals();
   cg_setup();
 
-  proxy_pid = clone(
-    box_proxy,			// Function to execute as the body of the new process
-    (void*)((uintptr_t)argv & ~(uintptr_t)15),	// Pass our stack, aligned to 16-bytes
-    SIGCHLD | CLONE_NEWIPC | (share_net ? 0 : CLONE_NEWNET) | CLONE_NEWNS | CLONE_NEWPID,
-    argv);			// Pass the arguments
+  struct clone_args cl_args = {
+    .exit_signal = SIGCHLD,
+    .flags = CLONE_NEWIPC | (share_net ? 0 : CLONE_NEWNET) | CLONE_NEWNS | CLONE_NEWPID,
+  };
+  proxy_pid = syscall(SYS_clone3, &cl_args, sizeof(cl_args));
   if (proxy_pid < 0)
     die("Cannot run proxy, clone failed: %m");
   if (!proxy_pid)
-    die("Cannot run proxy, clone returned 0");
+    box_proxy(argv);
 
   pid_t box_pid_inside_ns;
   int n = read(status_pipes[0], &box_pid_inside_ns, sizeof(box_pid_inside_ns));

--- a/isolate.c
+++ b/isolate.c
@@ -931,7 +931,6 @@ setup_seccomp(void)
 static int
 box_inside(char **args)
 {
-  cg_enter();
   setup_root();
   setup_net();
   setup_rlimits();
@@ -973,10 +972,8 @@ box_proxy(void *arg)
   lock_close();
   reset_signals();
 
-  pid_t inside_pid = fork();
-  if (inside_pid < 0)
-    die("Cannot run process, fork failed: %m");
-  else if (!inside_pid)
+  pid_t inside_pid = cg_fork_and_enter();
+  if (!inside_pid)
     {
       close(status_pipes[1]);
       box_inside(args);

--- a/isolate.h
+++ b/isolate.h
@@ -79,8 +79,8 @@ void cg_remove(void);
 // Prepare the box CG for use (during isolate --run)
 void cg_setup(void);
 
-// Move the current process to the box CG
-void cg_enter(void);
+// fork(), but spawn the child inside the box CG
+pid_t cg_fork_and_enter(void);
 
 // Obtain statistics on the box CG
 int cg_get_run_time_ms(void);


### PR DESCRIPTION
Closes #126.

Benchmarks:
Ran with `sudo hyperfine -N -L exe ./isolate,../isolate-old '{exe} --cg --box-id=1 --run -- /usr/bin/echo hi' -p 'sleep 0.01' --warmup 5`.
<img width="934" height="296" alt="image" src="https://github.com/user-attachments/assets/924a4862-9187-4a68-814a-960d96124bf2" />
(Separately running isolate in non-cg mode, I get 3.4 ms ± 0.7ms both before and after this patch, so I'm quite confident in claiming that this patch eliminates all overhead of the cgroups mode.)

The benchmarks are a little odd: I had to use `-p 'sleep 0.01'`, which means sleeping 10ms between each isolate invocation. Without it, the old isolate was basically just as fast as the new one. I guess it's something to do with the scheduler and jiffies, but i really don't know. I think a few ms of delay between isolate invocations is likely to be a slightly more representative benchmark anyway. In any case, this patch doesn't seem to ever make the performance worse.

Portability concerns: CLONE_INTO_CGROUP is defined in Linux 5.7 headers. We already unconditionally depend on Linux 5.14 headers for SYS_quotactl_fd, so this change doesn't change the requirements for compiling isolate. It does, however, require kernel 5.7 for *running* isolate in cg mode. Also, clone3 itself was only added in kernel 5.3, so this version is required in any case.

Supporting older kernels would be possible (basically just fall back to the old approach), but I think it would require somewhat annoying amounts of code duplication. Kernel 5.7 or newer is used in Debian 11, Ubuntu 22.04 and RHEL 9.